### PR TITLE
ci: upgrade action versions to use node 20

### DIFF
--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: go fmt project
         uses: Jerome1337/gofmt-action@v1.0.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,13 +30,13 @@ jobs:
     steps:
 
       - name: Set up Go 1.20
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.20.3
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Clean dependencies
         run: go clean --modcache


### PR DESCRIPTION
## Summary
* update actions/checkout to v4 to use node 20 runtime
  * v4 release notes: https://github.com/actions/checkout/releases/tag/v4.0.0
* update actions/setup-go to v5 to use node 20 runtime
  * v5 release notes: https://github.com/actions/setup-go/releases/tag/v5.0.0